### PR TITLE
Fix array reference bug on php 7, 8

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -43,7 +43,7 @@ yourls_add_filter( 'table_add_row_cell_array', 'tn_table_row' );
 function tn_table_row( $rowvalue ) {
 	$tnrow = array('preview' => array(
 			'template'      => '<img src="https://api.thumbnail.ws/api/'.THUMBNAIL_WS_API_KEY.'/thumbnail/get?url=%long_url%&width='.ADM_THUMBNAIL_WS_WIDTH.'" />',
-			'long_url'      => $rowvalue[url][long_url]
+			'long_url'      => $rowvalue["url"]["long_url"]
 		))+$rowvalue;
 		
 	return $tnrow;


### PR DESCRIPTION
Currently references two array props by use of is a constant in newer versions of php:
https://www.php.net/manual/en/language.types.array.php#language.types.array.donts

Fixes `PHP Fatal error:  Uncaught Error: Undefined constant "url" in user/plugins/tn/plugin.php:46`